### PR TITLE
fix: support for halowlink2

### DIFF
--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -179,6 +179,9 @@ ramips_setup_interfaces()
 	ruijie,rg-ew1200g-pro-v1.1)
 		ucidef_set_interfaces_lan_wan "lan3 lan2 lan1" "wan"
 		;;
+	morse,halowlink2)
+		ucidef_set_interfaces_lan_wan "usblan lan" "wan"
+		;;
 	*)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
 		;;


### PR DESCRIPTION
Fixes issues with board identification for network interface setup
