### PR TITLE
Enable I2C on Pi3 and Pi4

### DIFF
--- a/target/linux/bcm27xx/image/distroconfig.txt
+++ b/target/linux/bcm27xx/image/distroconfig.txt
@@ -10,7 +10,9 @@
 dtoverlay=disable-bt
 [pi3]
 dtoverlay=disable-bt
+dtparam=i2c1=on
 [pi4]
 dtoverlay=disable-bt
+dtparam=i2c1=on
 # Run as fast as firmware / board allows
 arm_boost=1


### PR DESCRIPTION
This enables I2C bus 1 on pi3 and pi4.  Bus 0 is usually on the GPU and hangs out the CSI connector.  This should enable functionality such as reading UPS hat status, communicating with additional sensors, and eeproms IDing some hats.

