### PR TITLE
boards/ht-hd01-v2: trigger build for MAGK mesh deployment

### DIFF
--- a/boards/ht-hd01-v2/target_diffconfig
+++ b/boards/ht-hd01-v2/target_diffconfig
@@ -84,3 +84,6 @@ CONFIG_PACKAGE_kmod-crypto-michael-mic=y
 CONFIG_PACKAGE_kmod-hwmon-core=y
 CONFIG_PACKAGE_kmod-pps=y
 CONFIG_PACKAGE_kmod-ptp=y
+
+# MAGK mesh node configuration marker
+# This board is used as a MAGK OpenMANET mesh node (HaLow backhaul)


### PR DESCRIPTION
## Summary
Adds a configuration comment to the HT-HD01 V2 board config to trigger CI build of the sysupgrade image.

## Purpose
We need a fresh HT-HD01 V2 sysupgrade.bin for deploying MAGK OpenMANET mesh nodes. The release workflow has this target commented out, so this PR triggers the `build-pr-hd01v2.yml` workflow to produce the artifact.

## Changes
- Added MAGK mesh node marker comment to `boards/ht-hd01-v2/target_diffconfig`
- No functional change to the build configuration

## Testing
CI build validation via `build-pr-hd01v2.yml` workflow.