### PR TITLE
feeds: pin focused Sunkworks fixes

### DIFF
--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -1,4 +1,4 @@
-src-git openmanet https://github.com/OpenMANET/packages.git^59d4a63350f9ff1e54e63ac5986c361af5165b31
+src-git openmanet https://github.com/OpenMANET/packages.git^1dbe5b5a4467dcd8c45f5b81769539773f66280f
 src-git morse https://github.com/MorseMicro/morse-feed.git^fc332b01aa2df952e057efe73763de3ff71cb3b0
 src-git gateworks https://github.com/Gateworks/gw-openwrt-packages.git^d1d23cd0059fbee84e8d5087b47d93213d8be587
 src-git packages https://github.com/openwrt/packages.git^953b6d47b4e9f0ad3c39547c6d3f9a828f10e206

--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -1,4 +1,4 @@
-src-git openmanet https://github.com/OpenMANET/packages.git^1dbe5b5a4467dcd8c45f5b81769539773f66280f
+src-git openmanet https://github.com/OpenMANET/packages.git^fa26b60a3d654fe01f26008e876da2a9c78fd5d7
 src-git morse https://github.com/MorseMicro/morse-feed.git^fc332b01aa2df952e057efe73763de3ff71cb3b0
 src-git gateworks https://github.com/Gateworks/gw-openwrt-packages.git^d1d23cd0059fbee84e8d5087b47d93213d8be587
 src-git packages https://github.com/openwrt/packages.git^953b6d47b4e9f0ad3c39547c6d3f9a828f10e206

--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -1,4 +1,4 @@
-src-git openmanet https://github.com/OpenMANET/packages.git^4736e44791166e3252ddbc4f050a784b8b5ab062
+src-git openmanet https://github.com/OpenMANET/packages.git^59d4a63350f9ff1e54e63ac5986c361af5165b31
 src-git morse https://github.com/MorseMicro/morse-feed.git^fc332b01aa2df952e057efe73763de3ff71cb3b0
 src-git gateworks https://github.com/Gateworks/gw-openwrt-packages.git^d1d23cd0059fbee84e8d5087b47d93213d8be587
 src-git packages https://github.com/openwrt/packages.git^953b6d47b4e9f0ad3c39547c6d3f9a828f10e206

--- a/target/linux/bcm27xx/image/Makefile
+++ b/target/linux/bcm27xx/image/Makefile
@@ -323,6 +323,7 @@ define Device/bcm2711_mm8108-usb
 	kmod-mm8108 netifd-morse mm8108-firmware \
 	kmod-video-ov5647 kmod-video-imx219 kmod-video-imx477 kmod-video-imx708
   SUPPORTED_DEVICES += morse,ekh01 morse,ekh01v1 morse,ekh01v2 morse,ekh01-03 morse,ekh01-05us bcm2711,mm8108-usb
+  DISTROCONFIG_EXTRA := mm810x-usb
 endef
 ifeq ($(SUBTARGET),bcm2711)
   TARGET_DEVICES += bcm2711_mm8108-usb

--- a/target/linux/bcm27xx/image/boards/ekh01/distroconfig-mm810x-usb.txt
+++ b/target/linux/bcm27xx/image/boards/ekh01/distroconfig-mm810x-usb.txt
@@ -1,0 +1,1 @@
+# MM810x USB transport requires no additional device-tree overlays.


### PR DESCRIPTION
Summary:
- pin OpenMANET/packages commit `fa26b60a3d654fe01f26008e876da2a9c78fd5d7` from OpenMANET/packages#24
- include the focused openmanetd setup/address-reservation fix from OpenMANET/openmanetd#180 through the packages feed
- include legacy wizard/BATMAN rerun fixes, optional ADS-B port/startup behavior, and BCM271x reset-service handling
- keep BLOS/Tailscale changes deferred to a separate PR

Verification:
- completed a clean local `ekh-bcm2711` build
- generated and checksum-verified RPi4 MM6108 SPI, MM6108 SDIO, and MM8108 USB images
- verified the assembled configuration contains the optional wizard reservation hook and ACL
- verified there is no `morsechipreset` boot symlink; the vendor helper payload remains installed by `morse-bundle` but is not scheduled automatically
- built adsbtocot and dump1090 as optional packages; they are not included in the image by default

Dependencies / merge order:
1. OpenMANET/openmanetd#180
2. OpenMANET/packages#24
3. This PR

Hardware acceptance and the wider board matrix remain pending, so this PR is intentionally a draft.