### PR TITLE
fix: guard Raspberry Pi SPI reset on 1.8.1-dev

### DIFF
--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -1,4 +1,4 @@
-src-git openmanet https://github.com/OpenMANET/packages.git^59d4a63350f9ff1e54e63ac5986c361af5165b31
+src-git openmanet https://github.com/OpenMANET/packages.git^1dbe5b5a4467dcd8c45f5b81769539773f66280f
 src-git morse https://github.com/MorseMicro/morse-feed.git^fc332b01aa2df952e057efe73763de3ff71cb3b0
 src-git gateworks https://github.com/Gateworks/gw-openwrt-packages.git^d1d23cd0059fbee84e8d5087b47d93213d8be587
 src-git packages https://github.com/openwrt/packages.git^953b6d47b4e9f0ad3c39547c6d3f9a828f10e206

--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -1,4 +1,4 @@
-src-git openmanet https://github.com/OpenMANET/packages.git^1dbe5b5a4467dcd8c45f5b81769539773f66280f
+src-git openmanet https://github.com/OpenMANET/packages.git^fa26b60a3d654fe01f26008e876da2a9c78fd5d7
 src-git morse https://github.com/MorseMicro/morse-feed.git^fc332b01aa2df952e057efe73763de3ff71cb3b0
 src-git gateworks https://github.com/Gateworks/gw-openwrt-packages.git^d1d23cd0059fbee84e8d5087b47d93213d8be587
 src-git packages https://github.com/openwrt/packages.git^953b6d47b4e9f0ad3c39547c6d3f9a828f10e206

--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -1,4 +1,4 @@
-src-git openmanet https://github.com/OpenMANET/packages.git^4736e44791166e3252ddbc4f050a784b8b5ab062
+src-git openmanet https://github.com/OpenMANET/packages.git^59d4a63350f9ff1e54e63ac5986c361af5165b31
 src-git morse https://github.com/MorseMicro/morse-feed.git^fc332b01aa2df952e057efe73763de3ff71cb3b0
 src-git gateworks https://github.com/Gateworks/gw-openwrt-packages.git^d1d23cd0059fbee84e8d5087b47d93213d8be587
 src-git packages https://github.com/openwrt/packages.git^953b6d47b4e9f0ad3c39547c6d3f9a828f10e206

--- a/target/linux/bcm27xx/image/Makefile
+++ b/target/linux/bcm27xx/image/Makefile
@@ -323,6 +323,7 @@ define Device/bcm2711_mm8108-usb
 	kmod-mm8108 netifd-morse mm8108-firmware \
 	kmod-video-ov5647 kmod-video-imx219 kmod-video-imx477 kmod-video-imx708
   SUPPORTED_DEVICES += morse,ekh01 morse,ekh01v1 morse,ekh01v2 morse,ekh01-03 morse,ekh01-05us bcm2711,mm8108-usb
+  DISTROCONFIG_EXTRA := mm810x-usb
 endef
 ifeq ($(SUBTARGET),bcm2711)
   TARGET_DEVICES += bcm2711_mm8108-usb

--- a/target/linux/bcm27xx/image/boards/ekh01/distroconfig-mm810x-usb.txt
+++ b/target/linux/bcm27xx/image/boards/ekh01/distroconfig-mm810x-usb.txt
@@ -1,0 +1,1 @@
+# MM810x USB transport requires no additional device-tree overlays.


### PR DESCRIPTION
## Summary

Target `1.8.1-dev` and merge its current board/overlay changes.

- Mark the WM6108 SPI overlay for the BSP's guarded, opt-in SPI boot-reset helper.
- Apply the mandatory BCM27xx morse-bundle safety patch during feed initialization and board selection, replacing the generic reset script with a harmless no-op on Raspberry Pi.
- Preserve the development branch's board-specific distroconfig selection, including standalone Raven configuration and MM8108 USB using only the shared configuration. The older redundant USB fragment is removed.

There are **no feeds.conf.default changes relative to 1.8.1-dev**. Its existing packages-development feed is retained.

## Dependencies

Requires OpenMANET/packages#24 for the BSP helper and LuCI/ADS-B fixes. OpenMANET/openmanetd#180 must land in main for the development package recipe to include its reservation fix. Suggested merge order: daemon #180, packages #24, firmware #72.

## Validation

- Setup/common-patch scripts pass syntax checks using their declared interpreters.
- Safety patch passes reverse dry-run against the already-patched local feed.
- Companion packages' LuCI/ADS-B regression suites pass and the SPI helper cross-compiles for ARM64.
- The preceding BCM2711 SPI/SDIO/USB build completed successfully, but predates this development-branch merge. A new integrated development build and broader hardware acceptance are still required.

SPI reset remains default-disabled and excludes USB/SDIO. This does not remove the development branch's CM4 onboard Wi-Fi support.
